### PR TITLE
Update README.md with spaces after header hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Tidy Tabs for Atom
+# Tidy Tabs for Atom
 
 ## Why and how
 Ever get to the end (middle?) of a day of coding only to find your window littered with tabs that are nearly impossible to search through visually? Find yourself rage-quitting all your tabs in disgust and starting over? No? Just me? Ok.
@@ -7,20 +7,20 @@ With this plugin, a simple keystroke `ctrl + alt + shift + w` will close all tab
 
 You can also configure the plugin to run automatically.
 
-##Configuration
+## Configuration
 
 You can configure the plugin by opening the Atom Settings pane, then clicking *Packages* in the left column, then searching for *tidy-tabs*. Click the *Settings* gear to make changes to the configuration.
 
-###Configuration options
+### Configuration options
 
-####Accessed threshold
+#### Accessed threshold
 Do not close tabs that have been accessed in the last *n* minutes.
 
-####Miniumum tabs
+#### Miniumum tabs
 Do not close tabs until there are more than this number of tabs open in the given pane.
 
-####Modified threshold
+#### Modified threshold
 Do not close tabs that have been modified in the last *n* minutes.
 
-####Run on save
+#### Run on save
 When enabled, Tidy Tabs will run every time a file is saved.


### PR DESCRIPTION
While GitHub's markdown parser is tolerant to no spaces after the header hashes, Atom's is not, so the README.md doesn't render quite right.

Reference:

![image](https://cloud.githubusercontent.com/assets/838674/23468469/23f733bc-fe5e-11e6-8399-7d42f9d53f87.png)
